### PR TITLE
feat: display list of examples from the command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:chkware.helloWorld"
+    "onCommand:chkware.copyExamples"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "chkware.helloWorld",
-        "title": "Hello World"
+        "command": "chkware.copyExamples",
+        "title": "Copy Examples",
+        "category": "Chkware"
       }
     ]
   },

--- a/src/copy-examples.ts
+++ b/src/copy-examples.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+import examples, { ExampleItem } from './examples';
+
+export async function copyExamples() {
+  createQuickPickExamples();
+}
+
+function pasteExample(item: ExampleItem) {
+  console.log(item);
+
+  // to do https://github.com/chkware/vscode-ext/issues/4
+}
+
+async function createQuickPickExamples() {
+  await vscode.window
+    .showQuickPick(examples, {
+      placeHolder: 'Select an example',
+    })
+    .then((item) => {
+      item && pasteExample(item);
+    });
+}

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -1,0 +1,5 @@
+export interface ExampleItem {
+  label: string;
+  description: string;
+  snippet: string;
+}

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -1,5 +1,10 @@
+import minimalRequest from './minimal-request';
+import requestWithQueryString from './request-with-query-string';
+
 export interface ExampleItem {
   label: string;
   description: string;
   snippet: string;
 }
+
+export default [minimalRequest, requestWithQueryString];

--- a/src/examples/minimal-request.ts
+++ b/src/examples/minimal-request.ts
@@ -1,0 +1,12 @@
+import { ExampleItem } from '.';
+
+export default <ExampleItem>{
+  label: 'Minimal request',
+  description: '',
+  snippet: `
+    ---
+    request:
+    url: https://example.org/api/path
+    method: GET
+    `,
+};

--- a/src/examples/request-with-query-string.ts
+++ b/src/examples/request-with-query-string.ts
@@ -1,0 +1,16 @@
+import { ExampleItem } from '.';
+
+export default <ExampleItem>{
+  label: 'Request with query string',
+  description: '',
+  snippet: `
+    ---
+    # put variables as url_params entry
+    request:
+    url: https://example.org/api/path
+    method: GET
+    url_params:
+        foo: bar
+        two: 2
+    `,
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,14 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-	
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "chkware" is now active!');
+  let disposable = vscode.commands.registerCommand(
+    'chkware.copyExamples',
+    () => {
+      //
+    }
+  );
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('chkware.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from Chkware!');
-	});
-
-	context.subscriptions.push(disposable);
+  context.subscriptions.push(disposable);
 }
 
-// this method is called when your extension is deactivated
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
+import { copyExamples } from './copy-examples';
 
 export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
     'chkware.copyExamples',
     () => {
-      //
+      copyExamples();
     }
   );
 


### PR DESCRIPTION
Close #7.

To run locally:
- run `npm run watch`
- press `f5`
- wait for the new window to be opened
- open command palette by pressing `ctrl` + `shift` + `p`
- search for `Chkware: copy examples` and select it

![image](https://user-images.githubusercontent.com/45073703/182198810-a4ae9bcf-a4c6-4a0a-a40b-29a9235607b3.png)
![image](https://user-images.githubusercontent.com/45073703/182198819-97332873-ef59-4039-b494-d9e337f0850e.png)
