### PR TITLE
feat: add command to run opened chk file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chkware",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chkware",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@commitlint/cli": "^17.0.3",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,23 @@
         "command": "chkware.addHttpSnippet",
         "title": "Add Http spec. snippet",
         "category": "CHKware"
-      }, {
+      },
+      {
         "command": "chkware.addTestCaseSnippet",
         "title": "Add Testcase spec. snippet",
         "category": "CHKware"
+      },
+      {
+        "command": "chkware.runFile",
+        "title": "Run file",
+        "category": "CHKware"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "chkware.runFile",
+        "key": "alt+ctrl+r",
+        "mac": "opt+ctrl+r"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,14 @@
         "category": "CHKware"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "chkware.runFile",
+          "when": "resourceExtname == .chk"
+        }
+      ]
+    },
     "keybindings": [
       {
         "command": "chkware.runFile",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "*.{md}": [
+    "*.md": [
       "prettier --write"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "keybindings": [
       {
         "command": "chkware.runFile",
-        "key": "alt+ctrl+r",
-        "mac": "opt+ctrl+r"
+        "key": "alt+ctrl+r"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -28,10 +28,6 @@
     "Formatters",
     "Testing"
   ],
-  "activationEvents": [
-    "onCommand:chkware.addHttpSnippet",
-    "onCommand:chkware.addTestCaseSnippet"
-  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [

--- a/src/commands/add-snippet.ts
+++ b/src/commands/add-snippet.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { testCaseSnippets, httpSnippets, SnippetItem } from "./snippets";
+import { testCaseSnippets, httpSnippets, SnippetItem } from "../snippets";
 
 export async function addHttpSnippet(): Promise<void> {
   const item = await vscode.window.showQuickPick(httpSnippets, {

--- a/src/commands/run-file.ts
+++ b/src/commands/run-file.ts
@@ -1,0 +1,50 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+export async function runFile(): Promise<void> {
+  const activeTextEditor: vscode.TextEditor | undefined =
+    vscode.window.activeTextEditor;
+
+  if (!activeTextEditor) {
+    vscode.window.showWarningMessage("Please open a chk file first.");
+    return;
+  }
+
+  const { openedFileName, openedFolder } = getFileInfo(
+    activeTextEditor.document
+  );
+
+  // check file extension
+  if (!openedFileName.endsWith(".chk")) {
+    vscode.window.showWarningMessage("Not a valid chk file to run.");
+    return;
+  }
+
+  const terminal = vscode.window.createTerminal({
+    name: "chkware - Run",
+    cwd: openedFolder,
+  });
+
+  terminal.show(true);
+
+  // GUI terminal needs some time to be opened
+  setTimeout(() => {
+    terminal.sendText(`chk http ${openedFileName}`);
+  }, 1000);
+}
+
+function getFileInfo(textDocument: vscode.TextDocument): {
+  openedFilePath: string;
+  openedFileName: string;
+  openedFolder: string;
+} {
+  const openedFilePath = textDocument.uri.fsPath;
+  const openedFileName = path.basename(openedFilePath);
+  const openedFolder = path.dirname(openedFilePath);
+
+  return {
+    openedFilePath,
+    openedFileName,
+    openedFolder,
+  };
+}

--- a/src/commands/run-file.ts
+++ b/src/commands/run-file.ts
@@ -6,7 +6,7 @@ export async function runFile(): Promise<void> {
     vscode.window.activeTextEditor;
 
   if (!activeTextEditor) {
-    vscode.window.showWarningMessage("Please open a chk file first.");
+    vscode.window.showWarningMessage("Please open a .chk file first.");
     return;
   }
 
@@ -18,7 +18,7 @@ export async function runFile(): Promise<void> {
 
   // check file extension and command type
   if (!openedFileName.endsWith(".chk") || !commandType) {
-    vscode.window.showWarningMessage("Not a valid chk file to run.");
+    vscode.window.showWarningMessage("Not a valid .chk file to run.");
     return;
   }
 
@@ -52,7 +52,7 @@ function getFileInfo(textDocument: vscode.TextDocument): {
 }
 
 function getCommandType(code: string): string | undefined {
-  // version: default:http:0.7.2 | version: 'default:http:0.7.2' | version: "default:http:0.7.2"
+  // e.g.: version: default:http:0.7.2 | version: 'default:http:0.7.2' | version: "default:http:0.7.2"
   const pattern = /version: *(?:'|")?default:([^'"]*)(?:'|")?/;
 
   const match = code.match(pattern); // http:0.7.2

--- a/src/commands/run-file.ts
+++ b/src/commands/run-file.ts
@@ -52,13 +52,14 @@ function getFileInfo(textDocument: vscode.TextDocument): {
 }
 
 function getCommandType(code: string): string | undefined {
+  // version: default:http:0.7.2 | version: 'default:http:0.7.2' | version: "default:http:0.7.2"
   const pattern = /version: *(?:'|")?default:([^'"]*)(?:'|")?/;
 
-  const match = code.match(pattern);
+  const match = code.match(pattern); // http:0.7.2
 
   if (match && match[1]) {
     const commandType = match[1].split(":");
 
-    return commandType[0];
+    return commandType[0]; // http
   }
 }

--- a/src/commands/run-file.ts
+++ b/src/commands/run-file.ts
@@ -14,8 +14,10 @@ export async function runFile(): Promise<void> {
     activeTextEditor.document
   );
 
-  // check file extension
-  if (!openedFileName.endsWith(".chk")) {
+  const commandType = getCommandType(activeTextEditor.document.getText());
+
+  // check file extension and command type
+  if (!openedFileName.endsWith(".chk") || !commandType) {
     vscode.window.showWarningMessage("Not a valid chk file to run.");
     return;
   }
@@ -29,7 +31,7 @@ export async function runFile(): Promise<void> {
 
   // GUI terminal needs some time to be opened
   setTimeout(() => {
-    terminal.sendText(`chk http ${openedFileName}`);
+    terminal.sendText(`chk ${commandType} ${openedFileName}`);
   }, 1000);
 }
 
@@ -47,4 +49,16 @@ function getFileInfo(textDocument: vscode.TextDocument): {
     openedFileName,
     openedFolder,
   };
+}
+
+function getCommandType(code: string): string | undefined {
+  const pattern = /version: *(?:'|")?default:([^'"]*)(?:'|")?/;
+
+  const match = code.match(pattern);
+
+  if (match && match[1]) {
+    const commandType = match[1].split(":");
+
+    return commandType[0];
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
-import { addHttpSnippet, addTestCaseSnippet } from "./add-snippet";
+import { addHttpSnippet, addTestCaseSnippet } from "./commands/add-snippet";
+import { runFile } from "./commands/run-file";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -12,5 +13,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("chkware.addTestCaseSnippet", () =>
       addTestCaseSnippet()
     )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("chkware.runFile", () => runFile())
   );
 }


### PR DESCRIPTION
Close #30.
Close #31.

The command can be run from the command palette or by keyboard shortcut: `alt+ctrl+r`. Should the keybinding be changed?

Also, not tested on Mac.